### PR TITLE
Workaround for wrong calculated code coverage if package and file name of external and internal packages are equal

### DIFF
--- a/.covignore
+++ b/.covignore
@@ -1,3 +1,4 @@
 ._mock\.go
 .test_fixture\.go
 test/.
+go.mongodb.org/mongo-driver/internal/logger/logger.go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,11 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
+      - name: "Code coverage" # known bug that files parameter is ignored https://github.com/codecov/codecov-action/issues/1285
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
       - name: "Build artifacts"
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
       - 'documentation/**'
 
 env:
-  MAJOR_MINOR_PATCH: 0.0.11
+  MAJOR_MINOR_PATCH: 0.0.12
   GIN_MODE: release
   MAIN_PACKAGE: 'cmd/file-store-svc/main.go'
 


### PR DESCRIPTION
- add go.mongodb.org/mongo-driver/internal/logger/logger.go to .covignore