### PR TITLE
Fix: Disconnect mongodb client on shutdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
       - 'documentation/**'
 
 env:
-  MAJOR_MINOR_PATCH: 0.0.13
+  MAJOR_MINOR_PATCH: 0.0.14
   GIN_MODE: release
   MAIN_PACKAGE: 'cmd/file-store-svc/main.go'
 

--- a/internal/app/persistence/database.go
+++ b/internal/app/persistence/database.go
@@ -19,13 +19,13 @@ type MongoDBConfig struct {
 }
 
 func ConnectToMongoDB(ctx context.Context, databaseConnected chan struct{}, databaseDisconnected chan struct{}, config MongoDBConfig) (file.FileMetadataRepository, error) {
+	logger.Logger.Debug().Msg("connecting to mongodb")
 	mongoDBRepository, err := initializeMongoDbFileMetadataRepository(ctx, config)
 	if err != nil {
 		close(databaseDisconnected)
 		return nil, err
 	}
 	go listenToGracefulShutdown(ctx, mongoDBRepository.client, databaseDisconnected)
-	logger.Logger.Debug().Msg("connecting to database")
 
 	close(databaseConnected)
 	return mongoDBRepository, nil

--- a/internal/app/server/database.go
+++ b/internal/app/server/database.go
@@ -28,7 +28,7 @@ func injectFileMetadaRepository(fileMetadataRepository file.FileMetadataReposito
 }
 
 func connectToMongoDB(ctx context.Context, databaseConnected chan struct{}, databaseDisconnected chan struct{}) (file.FileMetadataRepository, error) {
-	config, err := loadDatabaseConfig()
+	config, err := loadMongoDBConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -36,7 +36,7 @@ func connectToMongoDB(ctx context.Context, databaseConnected chan struct{}, data
 	return repository, err
 }
 
-func loadDatabaseConfig() (persistence.MongoDBConfig, error) {
+func loadMongoDBConfig() (persistence.MongoDBConfig, error) {
 	uri, found := os.LookupEnv(MongoDBUriEnv)
 	if !found {
 		return persistence.MongoDBConfig{}, fmt.Errorf("mongodb uri is not configured. Expected environment variable %v", MongoDBUriEnv)

--- a/internal/app/server/database.go
+++ b/internal/app/server/database.go
@@ -20,7 +20,7 @@ func InitializeDatabase(ctx context.Context, databaseConnected chan struct{}, da
 		os.Exit(51)
 	}
 
-	file.FileMetadataRepositoryInstance = fileMetadataRepository
+	injectFileMetadaRepository(fileMetadataRepository)
 }
 
 func injectFileMetadaRepository(fileMetadataRepository file.FileMetadataRepository) {

--- a/internal/app/server/database.go
+++ b/internal/app/server/database.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/kinneko-de/restaurant-file-store-svc/internal/app/file"
 	"github.com/kinneko-de/restaurant-file-store-svc/internal/app/operation/logger"
 	"github.com/kinneko-de/restaurant-file-store-svc/internal/app/persistence"
 )
@@ -12,21 +13,27 @@ import (
 const MongoDBUriEnv = "MONGODB_URI"
 const MongoDbDatabaseNameEnv = "MONGODB_DATABASE"
 
-func InitializeDatabase(ctx context.Context, databaseConnected chan struct{}, databaseStopped chan struct{}) {
-	err := connectToDatabase(ctx, databaseConnected, databaseStopped)
+func InitializeDatabase(ctx context.Context, databaseConnected chan struct{}, databaseDisconnected chan struct{}) {
+	fileMetadataRepository, err := connectToMongoDB(ctx, databaseConnected, databaseDisconnected)
 	if err != nil {
 		logger.Logger.Error().Err(err).Msg("failed to connect to database")
 		os.Exit(51)
 	}
+
+	file.FileMetadataRepositoryInstance = fileMetadataRepository
 }
 
-func connectToDatabase(ctx context.Context, databaseConnected chan struct{}, databaseStopped chan struct{}) error {
+func injectFileMetadaRepository(fileMetadataRepository file.FileMetadataRepository) {
+	file.FileMetadataRepositoryInstance = fileMetadataRepository
+}
+
+func connectToMongoDB(ctx context.Context, databaseConnected chan struct{}, databaseDisconnected chan struct{}) (file.FileMetadataRepository, error) {
 	config, err := loadDatabaseConfig()
 	if err != nil {
-		return err
+		return nil, err
 	}
-	err = persistence.ConnectToDatabase(ctx, databaseConnected, databaseStopped, config)
-	return err
+	repository, err := persistence.ConnectToMongoDB(ctx, databaseConnected, databaseDisconnected, config)
+	return repository, err
 }
 
 func loadDatabaseConfig() (persistence.MongoDBConfig, error) {

--- a/internal/app/server/database_component_test.go
+++ b/internal/app/server/database_component_test.go
@@ -17,7 +17,7 @@ func TestConnectToDatabase_ConfigIsComplete(t *testing.T) {
 	databaseConnected := make(chan struct{})
 	databaseStopped := make(chan struct{})
 
-	err := connectToDatabase(context.Background(), databaseConnected, databaseStopped)
+	_, err := connectToMongoDB(context.Background(), databaseConnected, databaseStopped)
 
 	assert.NoError(t, err)
 	// assert the database is connected is ensured over the ping of the client

--- a/internal/app/server/database_test.go
+++ b/internal/app/server/database_test.go
@@ -15,7 +15,7 @@ import (
 func TestConnectToDatabase_ConfigMissing_MongoDBUri(t *testing.T) {
 	t.Setenv(MongoDbDatabaseNameEnv, "testdatabase")
 
-	err := connectToDatabase(context.Background(), make(chan struct{}), make(chan struct{}))
+	_, err := connectToMongoDB(context.Background(), make(chan struct{}), make(chan struct{}))
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), MongoDBUriEnv)
@@ -24,7 +24,7 @@ func TestConnectToDatabase_ConfigMissing_MongoDBUri(t *testing.T) {
 func TestConnectToDatabase_ConfigMissing_MongoDBDatabase(t *testing.T) {
 	t.Setenv(MongoDBUriEnv, "mongodb://rootuser:rootpassword@mongodb:27017")
 
-	err := connectToDatabase(context.Background(), make(chan struct{}), make(chan struct{}))
+	_, err := connectToMongoDB(context.Background(), make(chan struct{}), make(chan struct{}))
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), MongoDbDatabaseNameEnv)
@@ -34,7 +34,7 @@ func TestConnectToDatabase_UriMalformed(t *testing.T) {
 	t.Setenv(MongoDBUriEnv, "invalidUri")
 	t.Setenv(MongoDbDatabaseNameEnv, "testdatabase")
 
-	err := connectToDatabase(context.Background(), make(chan struct{}), make(chan struct{}))
+	_, err := connectToMongoDB(context.Background(), make(chan struct{}), make(chan struct{}))
 
 	require.Error(t, err)
 }


### PR DESCRIPTION
- mongodb client disconnects if the server is shutdown
- restructure code to get client instance
- sent databaseDisconnected signal on connection error